### PR TITLE
Add custom S2I run code to complete database migration

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -10,6 +10,9 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
+# Allow S2I bin folder
+!.s2i/bin/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/app/.s2i/bin/run
+++ b/app/.s2i/bin/run
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+echo "---> Running data migration..."
+dotnet ef database update
+
+echo "---> Running application ..."
+dotnet run


### PR DESCRIPTION
The ASP.NET example app is deployed successfully with dotnet 1.0 image
but the register step is not working as 'no such table: AspNetUsers'
error will occur due to the fact the migrations for ApplicationDbContext
haven't been migrated to database CreateIdentitySchema yet. As a result,
the command 'dotnet ef database update' needs to be run to complete the
database migration process. In order to automatically run this command,
the custom S2I run code containing the command is needed. The S2I run
code is excuted when the application is run.

Signed-off-by: Vu Dinh <vdinh@redhat.com>