### PR TITLE
deps: fetch frontend deps using CDNs on dev mode

### DIFF
--- a/app/Views/Shared/_Layout.cshtml
+++ b/app/Views/Shared/_Layout.cshtml
@@ -5,11 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - WebApplication</title>
 
+    <!-- FIXME: To be used with bower install
+    See: https://github.com/openshift-s2i/s2i-aspnet-example/issues/7
+
     <environment names="Development">
         <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
         <link rel="stylesheet" href="~/css/site.css" />
-    </environment>
-    <environment names="Staging,Production">
+    </environment> -->
+    <environment names="Staging,Production,Development">
         <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.6/css/bootstrap.min.css"
               asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
               asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute" />
@@ -46,12 +49,15 @@
         </footer>
     </div>
 
+    <!-- FIXME: To be used with bower install
+    See: https://github.com/openshift-s2i/s2i-aspnet-example/issues/7
+
     <environment names="Development">
         <script src="~/lib/jquery/dist/jquery.js"></script>
         <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
         <script src="~/js/site.js" asp-append-version="true"></script>
-    </environment>
-    <environment names="Staging,Production">
+    </environment> -->
+    <environment names="Staging,Production,Development">
         <script src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-2.2.3.min.js"
                 asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
                 asp-fallback-test="window.jQuery">

--- a/app/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/app/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,8 +1,11 @@
+<!-- FIXME: To be used with bower install
+See: https://github.com/openshift-s2i/s2i-aspnet-example/issues/7
+
 <environment names="Development">
     <script src="~/lib/jquery-validation/dist/jquery.validate.js"></script>
     <script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js"></script>
-</environment>
-<environment names="Staging,Production">
+</environment> -->
+<environment names="Staging,Production,Development">
     <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.15.0/jquery.validate.min.js"
             asp-fallback-src="~/lib/jquery-validation/dist/jquery.validate.min.js"
             asp-fallback-test="window.jQuery && window.jQuery.validator">


### PR DESCRIPTION
On Development mode the frontend dependencies (bootstrap and jquery) are being fetched directly via CDN rather than fetched on build and used locally.

Currently the example's build is not running `bower install` so the frontend dependencies are not being fetched. In the future this should be handled by openshift-s2i/s2i-aspnet/s2i/assemble.
Addresses #7

@luciddreamz