### PR TITLE
Make .s2i/bin/run use exec to flatten the pstree

### DIFF
--- a/app/.s2i/bin/run
+++ b/app/.s2i/bin/run
@@ -6,4 +6,4 @@ echo "---> Running data migration..."
 dotnet ef database update
 
 echo "---> Running application ..."
-dotnet run
+exec dotnet run


### PR DESCRIPTION
This PR runs the last command in the .s2i/run script with exec, so that the process tree is more flat and signals are properly forwarded.

This PR complements openshift-s2i/s2i-aspnet#28.