### PR TITLE
1.0: install bower and gulp using custom assemble script

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# 'bower' and 'gulp' used to be installed by default by the dotnet-example template.
+# Since .NET Core 2.1 these tools are no longer required by the ASP.NET Core templates.
+# We manually install them here, to be able to remove them from the dotnet-example template.
+# see https://github.com/redhat-developer/s2i-dotnetcore/issues/192.
+echo "---> Installing npm tools..."
+pushd $HOME
+npm install bower gulp
+popd
+
+# Delegate to running the s2i builder's
+# assemble script.
+exec ${STI_SCRIPTS_PATH}/assemble

--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+pushd ~/src/${DOTNET_STARTUP_PROJECT}
+echo "---> Running data migration..."
+dotnet ef database update
+popd
+
+# Delegate to running the s2i builder's
+# run script.
+exec ${STI_SCRIPTS_PATH}/run

--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,0 +1,2 @@
+DOTNET_NPM_TOOLS=bower gulp
+DOTNET_PUBLISH=true

--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,2 +1,1 @@
-DOTNET_NPM_TOOLS=bower gulp
 DOTNET_PUBLISH=true


### PR DESCRIPTION
'bower' and 'gulp' used to be installed by default by the dotnet-example template.
Since .NET Core 2.x these tools are no longer required by the ASP.NET Core templates.
We manually install them here, to be able to remove them from the dotnet-example template.
see https://github.com/redhat-developer/s2i-dotnetcore/issues/192.