### PR TITLE
Make README consistent with s2i-dotnetcore-persistent-ex

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,66 +1,52 @@
-[[s2i-aspnet-example]]
 = .NET Core Sample App for OpenShift
 
-This repository contains an example project that can be built using the
-https://github.com/redhat-developer/s2i-dotnetcore[s2i-dotnetcore] builder
-image, which can be used to create reproducible Docker images from your .NET
-Core project's source code. The resulting images can be run using
-https://docker.com[Docker] or deployed to OpenShift.
+This repository contains a simple MVC .NET Core application that can be deployed on OpenShift.
 
-For more information about using these images with OpenShift, please see
-the official
-https://docs.openshift.com/enterprise/latest/using_images/s2i_images/dot_net_core.html[OpenShift
-Documentation].
+The example is meant to be built and run with the https://github.com/redhat-developer/s2i-dotnetcore[s2i-dotnetcore] builder
+images. The branches of this repository correspond to versions of the s2i-dotnetcore images.
 
-= Building and Running 
+= Deploying the application
 
-The sample application can be built and run either within OpenShift or
-standalone by combining the application using s2i tool and running with
-existing image using Docker. The following sections describes these processes.
-
-== OpenShift
-
-The dotnet-example template at https://github.com/redhat-developer/s2i-dotnetcore instantiates the example application.
-The https://github.com/redhat-developer/s2i-dotnetcore/blob/master/README.md[README.md] describes how to use the template.
-
-# Standalone
-
-To build a new .NET Core application using a previously existing s2i-dotnetcore
-builder, `dotnet/dotnet-30-rhel7`, execute the following command:
+== Deploy using the OpenShift client ('oc')
 
 [source]
 ----
-s2i build --ref=dotnetcore-3.0 --context-dir=app https://github.com/redhat-developer/s2i-dotnetcore-ex dotnet/dotnet-30-rhel7 aspnet-app
+# Create a new OpenShift project
+$ oc new-project mydemo
+
+# Add the .NET Core application
+$ oc new-app dotnet:3.1~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-3.1 --context-dir app
+
+# Make the .NET Core application accessible externally and show the url
+$ oc expose service s2i-dotnetcore-ex
+$ oc get route s2i-dotnetcore-ex
 ----
 
-The resulting image can be executed using docker:
+== Deploy using the OpenShift Do ('odo')
 
 [source]
 ----
-docker run -d -p 8080:8080 aspnet-app
+# Use git to check out the .NET Core application
+$ git clone https://github.com/redhat-developer/s2i-dotnetcore-ex
+$ cd s2i-dotnetcore-ex/app
+$ git checkout dotnetcore-3.1
+
+# Create a new OpenShift project
+$ odo project create mydemo
+
+# Add a component for the .NET Core application
+$ odo create dotnet:3.1
+
+# Make the .NET Core application accessible externally
+$ odo url create
+
+# Deploy the application
+$ odo push
 ----
 
-Once the container is running, it should be accessible using:
+== Copyright and License
 
-[source]
-----
-curl http://127.0.0.1:8080
-----
-
-[[contributing]]
-Contributing
-~~~~~~~~~~~~
-
-Contributions to this project (in the form of bug reports, patches, or pull
-requests) are gratefully accepted by the maintainer.  Please see the
-link:Contributing.adoc[Contributing.adoc] file contained in this package
-for details.
-
-[[copyright-license]]
-Copyright and License
-~~~~~~~~~~~~~~~~~~~~~
-
-Copyright 2016-2017 by Red Hat, Inc.
+Copyright 2016-2019 by Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this package except in compliance with the License (see the `LICENSE` file


### PR DESCRIPTION
This aligns the README with s2i-dotnetcore-persistent-ex repo and focuses on OpenShift usage (oc, odo), rather than stand-alone (s2i, docker, podman).

s2i-dotnetcore-persistent-ex uses `md` format. I kept the `adoc` format to avoid breaking the link.

@aslicerh @omajid is this change good for you?